### PR TITLE
Add iPhone-style chat UI with attractions cards and filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 import './chat.css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { sendChat } from './api/chat';
@@ -24,36 +24,111 @@ type ChatMessage = {
 };
 
 function AttractionsCards({ items }: { items: Attraction[] }) {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState<string>('All');
+  const [minRating, setMinRating] = useState<number>(0);
+  const [showFilter, setShowFilter] = useState(false);
+  const [page, setPage] = useState(1);
+  const pageSize = 9;
+
+  const categories = useMemo(() => {
+    const s = new Set<string>();
+    items.forEach((a: any) => {
+      const c = a?.category ?? a?.type ?? a?.category_name ?? a?.kind ?? null;
+      if (c) s.add(String(c));
+    });
+    return Array.from(s).sort((a, b) => a.localeCompare(b));
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return items.filter((a: any) => {
+      const cat = String(a?.category ?? a?.type ?? a?.category_name ?? 'Other');
+      const matchesCat = category === 'All' || cat === category;
+      const r = typeof a?.rating === 'number' ? a.rating : 0;
+      const matchesRating = !minRating || r >= minRating;
+      const text = [a.title, a.location, a.description].filter(Boolean).join(' ').toLowerCase();
+      const matchesQ = !q || text.includes(q);
+      return matchesCat && matchesRating && matchesQ;
+    });
+  }, [items, search, category, minRating]);
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  useEffect(() => { setPage(1); }, [search, category, minRating, items.length]);
+  const pageItems = filtered.slice((page - 1) * pageSize, page * pageSize);
+
   return (
-    <div className="attractions-cards" role="list">
-      {items.map((a, idx) => (
-        <article key={a.id ?? idx} className="attraction-card" role="listitem">
-          {a.imageUrl && (
-            <div className="attraction-image-wrap">
-              <img className="attraction-image" src={a.imageUrl} alt={a.title} loading="lazy" />
+    <div className="attractions-wrapper">
+      <div className="attractions-toolbar">
+        <div className="search-box">
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="#000" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"/></svg>
+          <input className="search-input" value={search} onChange={e => setSearch(e.target.value)} placeholder="Search attractions..." />
+        </div>
+        <div className="filter-group">
+          <button type="button" className="filter-trigger" onClick={() => setShowFilter(v => !v)}>
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path fill="#000" d="M3 5h18v2H3V5Zm4 6h10v2H7v-2Zm3 6h4v2h-4v-2Z"/></svg>
+            Filter
+          </button>
+          {showFilter && (
+            <div className="filter-panel">
+              <div className="filter-row">
+                <label className="filter-label">Category</label>
+                <select className="filter-select" value={category} onChange={e => setCategory(e.target.value)}>
+                  <option>All</option>
+                  {categories.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+              <div className="filter-row">
+                <label className="filter-label">Minimum Rating</label>
+                <select className="filter-select" value={minRating} onChange={e => setMinRating(Number(e.target.value))}>
+                  <option value={0}>Any Rating</option>
+                  <option value={3}>3.0+ Stars</option>
+                  <option value={3.5}>3.5+ Stars</option>
+                  <option value={4}>4.0+ Stars</option>
+                  <option value={4.5}>4.5+ Stars</option>
+                </select>
+              </div>
             </div>
           )}
-          <div className="attraction-body">
-            <h4 className="attraction-title">{a.title}</h4>
-            <div className="attraction-meta">
-              {a.location && (
-                <span className="attraction-location">
-                  <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#000" d="M12 2a7 7 0 0 0-7 7c0 4.6 6 11 6.6 11.6a.5.5 0 0 0 .8 0C13 20 19 13.6 19 9a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5Z"/></svg>
-                  {a.location}
-                </span>
-              )}
-              {typeof a.rating === 'number' && (
-                <span className="attraction-rating">
-                  <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#f2b01e" d="M12 2.5 14.9 9l6.6.5-5 4.2 1.6 6.3L12 16.9 5.9 20l1.6-6.3-5-4.2L9.1 9 12 2.5Z"/></svg>
-                  {a.rating?.toFixed(1)}
-                </span>
-              )}
+        </div>
+      </div>
+
+      <div className="attractions-cards" role="list">
+        {pageItems.map((a, idx) => (
+          <article key={a.id ?? idx} className="attraction-card" role="listitem">
+            {a.imageUrl && (
+              <div className="attraction-image-wrap">
+                <img className="attraction-image" src={a.imageUrl} alt={a.title} loading="lazy" />
+              </div>
+            )}
+            <div className="attraction-body">
+              <h4 className="attraction-title">{a.title}</h4>
+              <div className="attraction-meta">
+                {a.location && (
+                  <span className="attraction-location">
+                    <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#000" d="M12 2a7 7 0 0 0-7 7c0 4.6 6 11 6.6 11.6a.5.5 0 0 0 .8 0C13 20 19 13.6 19 9a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5Z"/></svg>
+                    {a.location}
+                  </span>
+                )}
+                {typeof a.rating === 'number' && (
+                  <span className="attraction-rating">
+                    <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#f2b01e" d="M12 2.5 14.9 9l6.6.5-5 4.2 1.6 6.3L12 16.9 5.9 20l1.6-6.3-5-4.2L9.1 9 12 2.5Z"/></svg>
+                    {a.rating?.toFixed(1)}
+                  </span>
+                )}
+              </div>
+              {a.description && <p className="attraction-desc">{a.description}</p>}
+              {a.link && <a href={a.link} target="_blank" rel="noreferrer" className="attraction-link">Read more</a>}
             </div>
-            {a.description && <p className="attraction-desc">{a.description}</p>}
-            {a.link && <a href={a.link} target="_blank" rel="noreferrer" className="attraction-link">Read more</a>}
-          </div>
-        </article>
-      ))}
+          </article>
+        ))}
+      </div>
+
+      <div className="attractions-pagination">
+        <button type="button" className="page-btn" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} aria-label="Previous page">‹</button>
+        <span className="page-indicator">Page {page} of {pageCount}</span>
+        <button type="button" className="page-btn" onClick={() => setPage(p => Math.min(pageCount, p + 1))} disabled={page === pageCount} aria-label="Next page">›</button>
+      </div>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,17 @@ export default function App() {
         </svg>
       </button>
 
-      <div className={`chat-widget${open ? ' open' : ''}`} role="dialog" aria-modal="true" aria-label="Chat widget">
+      <div className={`chat-overlay${open ? ' show' : ''}`} onClick={() => setOpen(false)} />
+
+      <div className={`chat-widget mobile-frame${open ? ' open' : ''}`} role="dialog" aria-modal="true" aria-label="Chat widget">
+        <div className="device-status-bar" aria-hidden="true">
+          <span className="status-time">9:41</span>
+          <div className="status-icons">
+            <span className="status-signal"></span>
+            <span className="status-wifi"></span>
+            <span className="status-battery"><span className="battery-level"></span></span>
+          </div>
+        </div>
         <div className="chat-widget-header">
           <div className="chat-widget-title">Chatbot</div>
           <div className="chat-endpoint">{apiBase.replace(/\/$/, '')}/chat</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,21 +95,26 @@ export default function App() {
       </header>
 
       {/* Floating chat widget */}
-      <button
-        type="button"
-        aria-label={open ? 'Close chat' : 'Open chat'}
-        className="chat-launcher"
-        onClick={() => setOpen(o => !o)}
-      >
-        {/* Modern chat/robot icon */}
-        <svg className="icon" viewBox="0 0 24 24" width="26" height="26" aria-hidden="true">
-          <path fill="#000" d="M12 2a1 1 0 0 1 1 1v1.05A7.5 7.5 0 0 1 20.5 11v3.5A3.5 3.5 0 0 1 17 18h-1.382l-2.724 2.724A1.75 1.75 0 0 1 9 19.75V18H7a3.5 3.5 0 0 1-3.5-3.5V11A7.5 7.5 0 0 1 11 4.05V3a1 1 0 0 1 1-1Zm-3.75 9.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm7.5 0a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"/>
-        </svg>
-      </button>
+      {!open && (
+        <button
+          type="button"
+          aria-label="Open chat"
+          className="chat-launcher"
+          onClick={() => setOpen(true)}
+        >
+          <svg className="icon" viewBox="0 0 24 24" width="26" height="26" aria-hidden="true">
+            <path fill="#000" d="M12 2a1 1 0 0 1 1 1v1.05A7.5 7.5 0 0 1 20.5 11v3.5A3.5 3.5 0 0 1 17 18h-1.382l-2.724 2.724A1.75 1.75 0 0 1 9 19.75V18H7a3.5 3.5 0 0 1-3.5-3.5V11A7.5 7.5 0 0 1 11 4.05V3a1 1 0 0 1 1-1Zm-3.75 9.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm7.5 0a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"/>
+          </svg>
+        </button>
+      )}
 
       <div className={`chat-overlay${open ? ' show' : ''}`} onClick={() => setOpen(false)} />
 
       <div className={`chat-widget mobile-frame${open ? ' open' : ''}`} role="dialog" aria-modal="true" aria-label="Chat widget">
+        <div className="device-notch" aria-hidden="true">
+          <span className="notch-speaker" />
+          <span className="notch-camera" />
+        </div>
         <div className="device-status-bar" aria-hidden="true">
           <span className="status-time">9:41</span>
           <div className="status-icons">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,7 @@ export default function App() {
 
   function normalizeAttractions(input: any): Attraction[] | null {
     const arr: any[] | undefined = Array.isArray(input?.attractionsData) ? input.attractionsData
+      : Array.isArray(input?.dbData) ? input.dbData
       : Array.isArray(input?.attractions) ? input.attractions
       : Array.isArray(input?.items) ? input.items
       : Array.isArray(input?.data) ? input.data
@@ -95,13 +96,16 @@ export default function App() {
     if (!arr || arr.length === 0) return null;
     return arr.map((it: any, idx: number): Attraction => {
       const title = it.title || it.name || it.placeName || `Attraction ${idx + 1}`;
-      const location = it.location || it.city || it.address || [it.city, it.state].filter(Boolean).join(', ');
+      const locName = typeof it.location === 'string' ? it.location : it.location?.name;
+      const location = locName || it.city || it.address || [it.city, it.state].filter(Boolean).join(', ');
       const ratingRaw = it.rating ?? it.stars ?? it.score;
       const rating = typeof ratingRaw === 'string' ? parseFloat(ratingRaw) : typeof ratingRaw === 'number' ? ratingRaw : undefined;
-      const imageUrl = it.imageUrl || it.image || it.photo || it.picture || it.thumbnail;
+      const firstImage = Array.isArray(it.imagelinks) ? it.imagelinks[0] : undefined;
+      const imageUrl = it.imageUrl || it.image || it.photo || it.picture || it.thumbnail || firstImage;
       const description = it.description || it.desc || it.summary || it.about;
       const link = it.link || it.url || it.more || undefined;
-      return { id: it.id ?? idx, title, location, rating, imageUrl, description, link };
+      const id = it.id ?? it.attraction_id ?? idx;
+      return { id, title, location, rating, imageUrl, description, link };
     });
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,63 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { sendChat } from './api/chat';
 
-type ChatMessage = {
-  role: 'user' | 'assistant';
-  kind: 'text' | 'markdown' | 'json';
-  text?: string;
-  json?: unknown;
+type Attraction = {
+  id?: string | number;
+  title: string;
+  location?: string;
+  rating?: number;
+  imageUrl?: string;
+  description?: string;
+  link?: string;
 };
 
+type ChatMessage = {
+  role: 'user' | 'assistant';
+  kind: 'text' | 'markdown' | 'json' | 'attractions';
+  text?: string;
+  json?: unknown;
+  attractions?: Attraction[];
+};
+
+function AttractionsCards({ items }: { items: Attraction[] }) {
+  return (
+    <div className="attractions-cards" role="list">
+      {items.map((a, idx) => (
+        <article key={a.id ?? idx} className="attraction-card" role="listitem">
+          {a.imageUrl && (
+            <div className="attraction-image-wrap">
+              <img className="attraction-image" src={a.imageUrl} alt={a.title} loading="lazy" />
+            </div>
+          )}
+          <div className="attraction-body">
+            <h4 className="attraction-title">{a.title}</h4>
+            <div className="attraction-meta">
+              {a.location && (
+                <span className="attraction-location">
+                  <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#000" d="M12 2a7 7 0 0 0-7 7c0 4.6 6 11 6.6 11.6a.5.5 0 0 0 .8 0C13 20 19 13.6 19 9a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5Z"/></svg>
+                  {a.location}
+                </span>
+              )}
+              {typeof a.rating === 'number' && (
+                <span className="attraction-rating">
+                  <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="#f2b01e" d="M12 2.5 14.9 9l6.6.5-5 4.2 1.6 6.3L12 16.9 5.9 20l1.6-6.3-5-4.2L9.1 9 12 2.5Z"/></svg>
+                  {a.rating?.toFixed(1)}
+                </span>
+              )}
+            </div>
+            {a.description && <p className="attraction-desc">{a.description}</p>}
+            {a.link && <a href={a.link} target="_blank" rel="noreferrer" className="attraction-link">Read more</a>}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
 function MessageContent({ m }: { m: ChatMessage }) {
+  if (m.kind === 'attractions' && m.attractions) {
+    return <AttractionsCards items={m.attractions} />;
+  }
   if (m.kind === 'json') {
     const pretty = JSON.stringify(m.json, null, 2);
     return (
@@ -37,10 +86,35 @@ export default function App() {
   const endRef = useRef<HTMLDivElement | null>(null);
   const apiBase = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000';
 
+  function normalizeAttractions(input: any): Attraction[] | null {
+    const arr: any[] | undefined = Array.isArray(input?.attractionsData) ? input.attractionsData
+      : Array.isArray(input?.attractions) ? input.attractions
+      : Array.isArray(input?.items) ? input.items
+      : Array.isArray(input?.data) ? input.data
+      : undefined;
+    if (!arr || arr.length === 0) return null;
+    return arr.map((it: any, idx: number): Attraction => {
+      const title = it.title || it.name || it.placeName || `Attraction ${idx + 1}`;
+      const location = it.location || it.city || it.address || [it.city, it.state].filter(Boolean).join(', ');
+      const ratingRaw = it.rating ?? it.stars ?? it.score;
+      const rating = typeof ratingRaw === 'string' ? parseFloat(ratingRaw) : typeof ratingRaw === 'number' ? ratingRaw : undefined;
+      const imageUrl = it.imageUrl || it.image || it.photo || it.picture || it.thumbnail;
+      const description = it.description || it.desc || it.summary || it.about;
+      const link = it.link || it.url || it.more || undefined;
+      return { id: it.id ?? idx, title, location, rating, imageUrl, description, link };
+    });
+  }
+
   function toAssistantMessage(data: unknown, contentType?: string): ChatMessage {
     if (contentType?.includes('application/json')) {
       try {
-        return { role: 'assistant', kind: 'json', json: typeof data === 'string' ? JSON.parse(data) : data };
+        const obj = typeof data === 'string' ? JSON.parse(data) : data;
+        const shouldShowCards = obj && (obj.text === '[attractionsData]' || obj.type === 'attractionsData' || obj.kind === 'attractions');
+        const normalized = normalizeAttractions(obj);
+        if (shouldShowCards && normalized) {
+          return { role: 'assistant', kind: 'attractions', attractions: normalized };
+        }
+        return { role: 'assistant', kind: 'json', json: obj };
       } catch {
         return { role: 'assistant', kind: 'json', json: data };
       }
@@ -51,6 +125,11 @@ export default function App() {
     if (typeof data === 'string') {
       try {
         const parsed = JSON.parse(data);
+        const normalized = normalizeAttractions(parsed);
+        const shouldShowCards = (parsed as any)?.text === '[attractionsData]' || (parsed as any)?.type === 'attractionsData' || (parsed as any)?.kind === 'attractions';
+        if (shouldShowCards && normalized) {
+          return { role: 'assistant', kind: 'attractions', attractions: normalized };
+        }
         return { role: 'assistant', kind: 'json', json: parsed };
       } catch {
         return { role: 'assistant', kind: 'markdown', text: data };
@@ -58,8 +137,13 @@ export default function App() {
     }
     if (data && typeof data === 'object') {
       const anyData = data as Record<string, unknown>;
+      const shouldShowCards = (anyData as any)?.text === '[attractionsData]' || (anyData as any)?.type === 'attractionsData' || (anyData as any)?.kind === 'attractions';
+      const normalized = normalizeAttractions(anyData);
+      if (shouldShowCards && normalized) {
+        return { role: 'assistant', kind: 'attractions', attractions: normalized };
+      }
       if (typeof anyData.reply === 'string') {
-        return { role: 'assistant', kind: 'markdown', text: anyData.reply };
+        return { role: 'assistant', kind: 'markdown', text: anyData.reply as string };
       }
       return { role: 'assistant', kind: 'json', json: data };
     }
@@ -140,7 +224,10 @@ export default function App() {
         <div className="chat-widget-body">
           <div className="chat-messages iphone-chat">
             {messages.map((m, i) => (
-              <div key={i} className={m.role === 'user' ? 'bubble bubble-user' : 'bubble bubble-assistant'}>
+              <div
+                key={i}
+                className={m.role === 'user' ? 'bubble bubble-user' : m.kind === 'attractions' ? 'bubble bubble-cards' : 'bubble bubble-assistant'}
+              >
                 <MessageContent m={m} />
               </div>
             ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 import './chat.css';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { sendChat } from './api/chat';
@@ -34,6 +34,7 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const endRef = useRef<HTMLDivElement | null>(null);
   const apiBase = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000';
 
   function toAssistantMessage(data: unknown, contentType?: string): ChatMessage {
@@ -88,6 +89,12 @@ export default function App() {
     }
   }
 
+  useEffect(() => {
+    if (open && endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, open]);
+
   return (
     <div className="App">
       <header className="App-header">
@@ -137,18 +144,32 @@ export default function App() {
                 <MessageContent m={m} />
               </div>
             ))}
+            <div ref={endRef} />
           </div>
           {error && <div className="chat-error" role="alert">{error}</div>}
         </div>
         <form className="chat-widget-input" onSubmit={onSubmit}>
-          <input
-            className="input prompt-input"
-            value={userPrompt}
-            onChange={e => setUserPrompt(e.target.value)}
-            placeholder="Type your message..."
-            aria-label="Message"
-          />
-          <button className="btn send-btn" type="submit" disabled={loading}>{loading ? '...' : 'Send'}</button>
+          <div className="composer">
+            <button type="button" className="composer-icon attach" aria-label="Attach">
+              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="#000" d="M16.5 6.5v8.25a4.75 4.75 0 1 1-9.5 0V6.25a3.25 3.25 0 1 1 6.5 0v7.75a1.75 1.75 0 1 1-3.5 0V7.5a.75.75 0 0 1 1.5 0v6.5a.25.25 0 1 0 .5 0V6.25a1.75 1.75 0 1 0-3.5 0v8.5a3.25 3.25 0 1 0 6.5 0V6.5a.75.75 0 0 1 1.5 0Z"/></svg>
+            </button>
+            <input
+              className="input prompt-input"
+              value={userPrompt}
+              onChange={e => setUserPrompt(e.target.value)}
+              placeholder="Type your message"
+              aria-label="Message"
+              type="text"
+            />
+            <button type="button" className="composer-icon emoji" aria-label="Emoji">
+              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="#000" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm-3 7a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 9 9Zm9 3a6 6 0 1 1-12 0 .75.75 0 0 1 1.5 0 4.5 4.5 0 1 0 9 0 .75.75 0 0 1 1.5 0ZM16 9a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 16 9Z"/></svg>
+            </button>
+          </div>
+          <button className="btn send-btn" type="submit" disabled={loading} aria-label="Send">
+            {loading ? <span>...</span> : (
+              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="#000" d="M2.3 3.3a1 1 0 0 1 1.1-.2l18 8a1 1 0 0 1 0 1.8l-18 8a1 1 0 0 1-1.4-1.2l2.3-6.2L13 12 4.3 9.5 2 3.9a1 1 0 0 1 .3-1Z"/></svg>
+            )}
+          </button>
         </form>
       </div>
     </div>

--- a/src/chat.css
+++ b/src/chat.css
@@ -52,3 +52,17 @@
 .btn:disabled { opacity: .6; cursor: not-allowed; }
 
 @media (max-width: 420px) { .chat-widget { width: calc(100% - 32px); } }
+
+/* Overlay that shows on open for mobile-like experience */
+.chat-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.35); opacity: 0; pointer-events: none; transition: opacity .2s ease; z-index: 999; }
+.chat-overlay.show { opacity: 1; pointer-events: auto; }
+
+/* Device-like frame and status bar */
+.chat-widget.mobile-frame { border-radius: 28px; border: 2px solid rgba(0,0,0,0.9); padding-top: 8px; box-shadow: 0 24px 60px rgba(0,0,0,0.35); }
+.device-status-bar { height: 18px; display: flex; align-items: center; justify-content: space-between; padding: 2px 10px 0; font-size: 11px; color: #000; background: #fff; border-top-left-radius: 26px; border-top-right-radius: 26px; }
+.status-icons { display: flex; align-items: center; gap: 6px; }
+.status-signal, .status-wifi { width: 14px; height: 10px; border: 1.5px solid #000; border-radius: 2px; position: relative; }
+.status-wifi::before { content: ''; position: absolute; inset: 2px; border-top: 2px solid #000; border-left: 2px solid transparent; border-right: 2px solid transparent; border-bottom: 0; border-radius: 50%; }
+.status-battery { width: 18px; height: 10px; border: 1.5px solid #000; border-radius: 2px; display: inline-flex; align-items: center; padding: 1px; position: relative; }
+.status-battery::after { content: ''; position: absolute; right: -3px; top: 3px; width: 2px; height: 4px; background: #000; border-radius: 1px; }
+.battery-level { width: 60%; height: 100%; background: #000; border-radius: 1px; }

--- a/src/chat.css
+++ b/src/chat.css
@@ -44,6 +44,7 @@
 .bubble { max-width: 80%; padding: 8px 12px; border-radius: 18px; line-height: 1.4; word-wrap: break-word; }
 .bubble-user { align-self: flex-end; background: #61dafb; color: #000; border-bottom-right-radius: 4px; }
 .bubble-assistant { align-self: flex-start; background: #f2f2f7; color: #000; border-bottom-left-radius: 4px; }
+.bubble-cards { align-self: stretch; background: transparent; padding: 0; max-width: 100%; }
 
 /* Input */
 .chat-widget-input { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 10px 14px 18px; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px; background: #fff; align-items: center; }
@@ -63,6 +64,19 @@
 .actions { display: flex; justify-content: flex-end; }
 .btn { padding: 8px 14px; border-radius: 8px; border: 1px solid rgba(255, 255, 255, 0.2); background: #61dafb; color: #000; cursor: pointer; }
 .btn:disabled { opacity: .6; cursor: not-allowed; }
+
+/* Attractions cards */
+.attractions-cards { display: grid; grid-template-columns: 1fr; gap: 12px; }
+.attraction-card { background: #fff; color: #000; border-radius: 16px; box-shadow: 0 6px 18px rgba(0,0,0,0.08); overflow: hidden; border: 1px solid rgba(0,0,0,0.06); }
+.attraction-image-wrap { width: 100%; aspect-ratio: 16/9; background: #f2f2f7; }
+.attraction-image { width: 100%; height: 100%; object-fit: cover; display: block; }
+.attraction-body { padding: 12px; display: grid; gap: 8px; }
+.attraction-title { margin: 0; font-size: 16px; font-weight: 600; }
+.attraction-meta { display: flex; align-items: center; gap: 12px; font-size: 12px; opacity: .85; }
+.attraction-location { display: inline-flex; align-items: center; gap: 4px; }
+.attraction-rating { display: inline-flex; align-items: center; gap: 4px; }
+.attraction-desc { margin: 0; font-size: 13px; color: #000; opacity: .9; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.attraction-link { color: #61dafb; font-weight: 600; font-size: 13px; text-decoration: none; }
 
 /* Perfect iPhone frame */
 .chat-widget.mobile-frame { --phone-w: 390px; --phone-h: 844px; --scale-x: calc((100vw - 32px) / var(--phone-w)); --scale-y: calc((100vh - 32px) / var(--phone-h)); --scale: min(var(--scale-x), var(--scale-y)); width: var(--phone-w); height: var(--phone-h); left: 50%; top: 50%; right: auto; bottom: auto; transform: translate(-50%, -50%) scale(var(--scale)); border-radius: 42px; border: 2.5px solid #000; box-shadow: 0 24px 60px rgba(0,0,0,0.35); grid-template-rows: 26px auto auto 1fr auto; padding: 0; background: #fff; }

--- a/src/chat.css
+++ b/src/chat.css
@@ -1,13 +1,16 @@
+/* Layout (unchanged core styles kept) */
 .chat-layout { width: 100%; max-width: 720px; margin: 0 auto; padding: 16px; }
 .chat-header { display: flex; justify-content: space-between; align-items: center; width: 100%; margin: 0 0 12px; }
 .chat-title { margin: 0; font-size: 20px; }
 .chat-endpoint { font-size: 12px; opacity: .8; text-align: right; word-break: break-all; }
+
+/* Messages */
 .chat-messages { width: 100%; max-height: 50vh; overflow: auto; display: flex; flex-direction: column; gap: 8px; margin: 8px 0 12px; }
 .msg { padding: 8px 12px; border-radius: 12px; background: rgba(255, 255, 255, 0.08); }
 .msg-user { align-self: flex-end; background: rgba(97, 218, 251, 0.25); }
 .msg-assistant { align-self: flex-start; }
 
-/* Markdown styles */
+/* Markdown */
 .md { line-height: 1.5; }
 .md h1, .md h2, .md h3 { margin: 8px 0; font-weight: 600; }
 .md p { margin: 6px 0; }
@@ -19,18 +22,22 @@
 .json-pre { margin: 6px 0; padding: 10px; border-radius: 8px; background: #f6f8fa; color: #000; overflow: auto; }
 .json-code { font-family: Menlo, Monaco, Consolas, 'Courier New', monospace; font-size: 12px; }
 
-/* Floating launcher */
+/* Launcher */
 .chat-launcher { position: fixed; right: 16px; bottom: 16px; width: 56px; height: 56px; border-radius: 50%; border: 0; background: #61dafb; color: #000; display: grid; place-items: center; box-shadow: 0 8px 24px rgba(0,0,0,0.35); cursor: pointer; z-index: 1000; }
 .chat-launcher .icon { display: block; }
 .chat-launcher:active { transform: translateY(1px); }
 
-/* Widget shell */
+/* Overlay */
+.chat-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); opacity: 0; pointer-events: none; transition: opacity .2s ease; z-index: 999; }
+.chat-overlay.show { opacity: 1; pointer-events: auto; }
+
+/* Base widget */
 .chat-widget { position: fixed; right: 16px; bottom: 84px; width: 360px; max-width: calc(100% - 32px); background: #fff; color: #000; border-radius: 16px; box-shadow: 0 16px 40px rgba(0,0,0,0.15); display: grid; grid-template-rows: auto 1fr auto; opacity: 0; transform: translateY(8px); pointer-events: none; transition: opacity .2s ease, transform .2s ease; z-index: 1000; }
 .chat-widget.open { opacity: 1; transform: translateY(0); pointer-events: auto; }
 .chat-widget-header { display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 8px; padding: 10px 12px; background: #fff; border-top-left-radius: 16px; border-top-right-radius: 16px; }
 .chat-widget-title { font-weight: 600; }
 .chat-close { border: 0; background: transparent; cursor: pointer; padding: 6px; border-radius: 6px; }
-.chat-widget-body { padding: 10px 12px; max-height: 50vh; overflow: hidden; display: grid; grid-template-rows: 1fr auto; }
+.chat-widget-body { padding: 10px 12px; overflow: hidden; display: grid; grid-template-rows: 1fr auto; height: auto; }
 
 /* iPhone-like bubbles */
 .iphone-chat { display: flex; flex-direction: column; gap: 8px; overflow: auto; padding-right: 4px; }
@@ -38,11 +45,12 @@
 .bubble-user { align-self: flex-end; background: #61dafb; color: #000; border-bottom-right-radius: 4px; }
 .bubble-assistant { align-self: flex-start; background: #f2f2f7; color: #000; border-bottom-left-radius: 4px; }
 
+/* Input */
 .chat-widget-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; padding: 10px 12px 12px; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px; background: #fff; }
 .prompt-input { background: #fff; color: #000; border: 1px solid rgba(0,0,0,0.15); border-radius: 10px; padding: 10px; }
 .send-btn { background: #61dafb; color: #000; border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; padding: 8px 14px; }
 
-/* Keep previous form styles for any inline usage */
+/* Alerts */
 .chat-error { background: #8b0000; color: #fff; padding: 8px 12px; border-radius: 8px; margin: 8px 12px; }
 .chat-form .row { display: flex; flex-direction: column; gap: 6px; margin: 0 0 10px; }
 .label { font-size: 12px; opacity: .9; }
@@ -51,18 +59,27 @@
 .btn { padding: 8px 14px; border-radius: 8px; border: 1px solid rgba(255, 255, 255, 0.2); background: #61dafb; color: #000; cursor: pointer; }
 .btn:disabled { opacity: .6; cursor: not-allowed; }
 
-@media (max-width: 420px) { .chat-widget { width: calc(100% - 32px); } }
+/* Perfect iPhone frame */
+.chat-widget.mobile-frame { --phone-w: 390px; --phone-h: 844px; --scale-x: calc((100vw - 32px) / var(--phone-w)); --scale-y: calc((100vh - 32px) / var(--phone-h)); --scale: min(var(--scale-x), var(--scale-y)); width: var(--phone-w); height: var(--phone-h); left: 50%; top: 50%; right: auto; bottom: auto; transform: translate(-50%, -50%) scale(var(--scale)); border-radius: 42px; border: 2.5px solid #000; box-shadow: 0 24px 60px rgba(0,0,0,0.35); grid-template-rows: 26px auto auto 1fr auto; padding: 0; background: #fff; }
 
-/* Overlay that shows on open for mobile-like experience */
-.chat-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.35); opacity: 0; pointer-events: none; transition: opacity .2s ease; z-index: 999; }
-.chat-overlay.show { opacity: 1; pointer-events: auto; }
+/* Notch + sensors */
+.device-notch { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); width: 210px; height: 32px; background: #000; border-bottom-left-radius: 22px; border-bottom-right-radius: 22px; border-top-left-radius: 22px; border-top-right-radius: 22px; display: flex; align-items: center; justify-content: center; gap: 16px; z-index: 3; }
+.notch-speaker { width: 62px; height: 6px; background: #222; border-radius: 3px; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08); }
+.notch-camera { width: 12px; height: 12px; background: radial-gradient(circle at 35% 35%, #4ec3ff 0 20%, #1b6ea7 21% 50%, #000 51%); border-radius: 50%; box-shadow: 0 0 0 2px #0a0a0a; }
 
-/* Device-like frame and status bar */
-.chat-widget.mobile-frame { border-radius: 28px; border: 2px solid rgba(0,0,0,0.9); padding-top: 8px; box-shadow: 0 24px 60px rgba(0,0,0,0.35); }
-.device-status-bar { height: 18px; display: flex; align-items: center; justify-content: space-between; padding: 2px 10px 0; font-size: 11px; color: #000; background: #fff; border-top-left-radius: 26px; border-top-right-radius: 26px; }
-.status-icons { display: flex; align-items: center; gap: 6px; }
+/* Status bar below notch */
+.device-status-bar { height: 26px; display: flex; align-items: center; justify-content: space-between; padding: 0 14px; font-size: 12px; color: #000; background: #fff; border-top-left-radius: 42px; border-top-right-radius: 42px; position: relative; z-index: 2; }
+.status-icons { display: flex; align-items: center; gap: 8px; }
 .status-signal, .status-wifi { width: 14px; height: 10px; border: 1.5px solid #000; border-radius: 2px; position: relative; }
 .status-wifi::before { content: ''; position: absolute; inset: 2px; border-top: 2px solid #000; border-left: 2px solid transparent; border-right: 2px solid transparent; border-bottom: 0; border-radius: 50%; }
-.status-battery { width: 18px; height: 10px; border: 1.5px solid #000; border-radius: 2px; display: inline-flex; align-items: center; padding: 1px; position: relative; }
+.status-battery { width: 20px; height: 10px; border: 1.5px solid #000; border-radius: 2px; display: inline-flex; align-items: center; padding: 1px; position: relative; }
 .status-battery::after { content: ''; position: absolute; right: -3px; top: 3px; width: 2px; height: 4px; background: #000; border-radius: 1px; }
-.battery-level { width: 60%; height: 100%; background: #000; border-radius: 1px; }
+.battery-level { width: 62%; height: 100%; background: #000; border-radius: 1px; }
+
+/* Header/body/input inside phone */
+.chat-widget.mobile-frame .chat-widget-header { padding: 10px 14px; border-radius: 0; border-top-left-radius: 0; border-top-right-radius: 0; }
+.chat-widget.mobile-frame .chat-widget-body { padding: 10px 14px; height: auto; max-height: none; }
+.chat-widget.mobile-frame .chat-widget-input { padding: 10px 14px 18px; border-radius: 0 0 42px 42px; }
+
+/* Responsive fallback width when viewport is tiny */
+@media (max-width: 420px) { .chat-widget { width: calc(100% - 32px); } }

--- a/src/chat.css
+++ b/src/chat.css
@@ -46,9 +46,14 @@
 .bubble-assistant { align-self: flex-start; background: #f2f2f7; color: #000; border-bottom-left-radius: 4px; }
 
 /* Input */
-.chat-widget-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; padding: 10px 12px 12px; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px; background: #fff; }
-.prompt-input { background: #fff; color: #000; border: 1px solid rgba(0,0,0,0.15); border-radius: 10px; padding: 10px; }
-.send-btn { background: #61dafb; color: #000; border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; padding: 8px 14px; }
+.chat-widget-input { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 10px 14px 18px; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px; background: #fff; align-items: center; }
+.composer { display: flex; align-items: center; gap: 8px; border: 1px solid rgba(0,0,0,0.12); background: #f2f2f7; color: #000; border-radius: 22px; padding: 6px 8px; }
+.composer-icon { width: 28px; height: 28px; border: 0; background: transparent; color: #000; border-radius: 50%; display: inline-grid; place-items: center; opacity: .7; cursor: pointer; }
+.composer-icon:active { transform: scale(0.98); }
+.prompt-input { background: transparent; color: #000; border: 0; border-radius: 0; padding: 8px; height: 38px; flex: 1; }
+.prompt-input:focus { outline: none; }
+.send-btn { background: #61dafb; color: #000; border: 1px solid rgba(255,255,255,0.2); border-radius: 22px; padding: 0; width: 44px; height: 44px; display: inline-grid; place-items: center; }
+.chat-widget.mobile-frame .chat-messages { height: 100%; max-height: none; }
 
 /* Alerts */
 .chat-error { background: #8b0000; color: #fff; padding: 8px 12px; border-radius: 8px; margin: 8px 12px; }

--- a/src/chat.css
+++ b/src/chat.css
@@ -66,6 +66,17 @@
 .btn:disabled { opacity: .6; cursor: not-allowed; }
 
 /* Attractions cards */
+.attractions-wrapper { display: grid; gap: 12px; }
+.attractions-toolbar { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; }
+.search-box { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid rgba(0,0,0,0.12); background: #fff; color: #000; border-radius: 999px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+.search-input { border: 0; outline: none; background: transparent; color: #000; width: 100%; }
+.filter-group { position: relative; }
+.filter-trigger { display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; border: 0; border-radius: 999px; background: #ff6b6b; color: #fff; box-shadow: 0 2px 8px rgba(0,0,0,0.08); cursor: pointer; }
+.filter-panel { position: absolute; right: 0; top: calc(100% + 8px); width: 240px; background: #fff; color: #000; border-radius: 12px; box-shadow: 0 12px 24px rgba(0,0,0,0.12); border: 1px solid rgba(0,0,0,0.06); padding: 10px; z-index: 5; }
+.filter-row { display: grid; gap: 6px; margin: 0 0 8px; }
+.filter-label { font-size: 12px; opacity: .8; }
+.filter-select { width: 100%; padding: 8px; border-radius: 8px; border: 1px solid rgba(0,0,0,0.15); background: #fff; color: #000; }
+
 .attractions-cards { display: grid; grid-template-columns: 1fr; gap: 12px; }
 .attraction-card { background: #fff; color: #000; border-radius: 16px; box-shadow: 0 6px 18px rgba(0,0,0,0.08); overflow: hidden; border: 1px solid rgba(0,0,0,0.06); }
 .attraction-image-wrap { width: 100%; aspect-ratio: 16/9; background: #f2f2f7; }
@@ -77,6 +88,11 @@
 .attraction-rating { display: inline-flex; align-items: center; gap: 4px; }
 .attraction-desc { margin: 0; font-size: 13px; color: #000; opacity: .9; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .attraction-link { color: #61dafb; font-weight: 600; font-size: 13px; text-decoration: none; }
+
+.attractions-pagination { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 6px 0 2px; }
+.page-btn { width: 32px; height: 32px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.15); background: #fff; color: #000; display: grid; place-items: center; }
+.page-btn:disabled { opacity: .5; }
+.page-indicator { font-size: 12px; opacity: .85; }
 
 /* Perfect iPhone frame */
 .chat-widget.mobile-frame { --phone-w: 390px; --phone-h: 844px; --scale-x: calc((100vw - 32px) / var(--phone-w)); --scale-y: calc((100vh - 32px) / var(--phone-h)); --scale: min(var(--scale-x), var(--scale-y)); width: var(--phone-w); height: var(--phone-h); left: 50%; top: 50%; right: auto; bottom: auto; transform: translate(-50%, -50%) scale(var(--scale)); border-radius: 42px; border: 2.5px solid #000; box-shadow: 0 24px 60px rgba(0,0,0,0.35); grid-template-rows: 26px auto auto 1fr auto; padding: 0; background: #fff; }


### PR DESCRIPTION
## Purpose

The user wanted to create a perfect iPhone-like chat interface with modern design elements. They specifically requested:
- iPhone structure with proper dimensions, camera, speaker, and status bar
- WhatsApp-style chat interface with search bar and send button
- Attraction cards display when backend sends `[attractionsData]` responses
- Filter functionality and pagination for attraction listings
- Modern, polished mobile interface that disappears the launcher button when opened

## Code changes

- **iPhone Frame**: Added complete iPhone mockup with notch, camera, speaker, status bar, and proper scaling
- **Chat Interface**: Redesigned chat widget with WhatsApp-style composer, rounded input field, and proper bubble styling
- **Attractions Component**: Created `AttractionsCards` component with search, category filters, rating filters, and pagination
- **Data Processing**: Added `normalizeAttractions` function to handle various backend data formats for attractions
- **Message Types**: Extended `ChatMessage` type to support attractions display alongside existing text/json formats
- **Responsive Design**: Added mobile-first responsive design with proper scaling for different screen sizes
- **UI Polish**: Enhanced styling with modern shadows, rounded corners, and smooth transitionsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/734f1f11a54c4c2888451845a7de5cfd/glow-studio)

👀 [Preview Link](https://734f1f11a54c4c2888451845a7de5cfd-glow-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>734f1f11a54c4c2888451845a7de5cfd</projectId>-->
<!--<branchName>glow-studio</branchName>-->